### PR TITLE
ビルド時に画像の吐き出し先が正しくなるよう修正

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -1,7 +1,7 @@
 const gulp = require('gulp');
 const rename = require('gulp-rename');
 
-const { static: config } = require('./config');
+const { assetRoot, static: config } = require('./config');
 
 exports.copy = callback => {
   gulp
@@ -15,7 +15,7 @@ exports.copy = callback => {
     .pipe(gulp.dest(config.dest));
 
   gulp
-    .src(config.assets)
+    .src(config.assets, { base: assetRoot })
     .pipe(gulp.dest(config.dest));
 
   callback();


### PR DESCRIPTION
## 概要
ビルド時に画像の吐き出し先が正しくなるよう修正
ビルド先のルートに`img`フォルダが吐き出されていたため、`assets/img`フォルダには吐き出されるよう修正
